### PR TITLE
imp: prepare proposal contents using templating

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -11,4 +11,5 @@ jobs:
     steps:
       - name: Check Changelog for changes
         uses: tarides/changelog-check-action@v2
-            
+        with:
+          changelog: CHANGELOG.md

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,12 +10,14 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
     - name: Build
       run: cargo build --verbose
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
     - name: Run tests
       run: cargo test --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # VS Code files
 /.vscode
+
+# JetBrains IDE files
+/.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,6 @@
 
 ### Improvements
 
+- [#5](https://github.com/MalteHerrmann/upgrade-helper/pull/5) Prepare proposal contents depending on input.
 - [#4](https://github.com/MalteHerrmann/upgrade-helper/pull/4) Check if release already exists on GitHub.
 - [#3](https://github.com/MalteHerrmann/upgrade-helper/pull/3) Add basic CLI structure.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +118,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +149,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -243,6 +281,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "gimli"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +313,20 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "handlebars"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39b3bc2a8f715298032cf5087e58573809374b08160aa7d750582bdb82d2683"
+dependencies = [
+ "log",
+ "pest",
+ "pest_derive",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -600,6 +662,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
+name = "pest"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c022f1e7b65d6a24c0dbbd5fb344c66881bc01f3e5ae74a1c8100f2f985d98a4"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35513f630d46400a977c4cb58f78e1bfbe01434316e60c37d27b9ad6139c66d8"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9fc1b9e7057baba189b5c626e2d6f40681ae5b6eb064dc7c7834101ec8123a"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df74e9e7ec4053ceb980e7c0c8bd3594e977fde1af91daba9c928e8e8c6708d"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,6 +934,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,6 +1161,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,9 +1209,11 @@ checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 name = "upgrade-helper"
 version = "0.1.0"
 dependencies = [
+ "handlebars",
  "inquire",
  "regex",
  "reqwest",
+ "serde_json",
 ]
 
 [[package]]
@@ -1100,6 +1232,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+handlebars = "4.4.0"
 inquire = "0.6.2"
 regex = "1.10.2"
 reqwest = { version="0.11.22", features=["blocking"] }
+serde_json = "1.0.107"

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -13,10 +13,10 @@ impl UpgradeHelper {
     /// 
     /// * `network` - The network type used.
     /// * `target_version` - The target version to upgrade to.
-    pub fn new(network: Network, target_version: String) -> UpgradeHelper {
+    pub fn new(network: Network, target_version: &str) -> UpgradeHelper {
         UpgradeHelper {
-            network,
-            target_version,
+            network: network,
+            target_version: target_version.to_string(),
         }
     }
 
@@ -58,7 +58,7 @@ mod tests {
     fn test_check_target_version_local_node_pass() {
         let helper = UpgradeHelper::new( 
             network::Network::LocalNode, 
-            "v14.0.0".to_string(),
+            "v14.0.0",
         );
         assert_eq!(helper.check_target_version(), true);
     }
@@ -67,7 +67,7 @@ mod tests {
     fn test_check_target_version_local_node_fail() {
         let helper = UpgradeHelper::new( 
             network::Network::LocalNode, 
-            "v14.0".to_string() ,
+            "v14.0",
         );
         assert_eq!(helper.check_target_version(), false);
     }
@@ -76,7 +76,7 @@ mod tests {
     fn test_check_target_version_testnet_pass() {
         let helper = UpgradeHelper::new(
             network::Network::Testnet,
-            "v14.0.0-rc1".to_string(),
+            "v14.0.0-rc1",
         );
         assert_eq!(helper.check_target_version(), true);
     }
@@ -85,7 +85,7 @@ mod tests {
     fn test_check_target_version_testnet_fail() {
         let helper = UpgradeHelper::new(
             network::Network::Testnet,
-            "v14.0.0".to_string(),
+            "v14.0.0",
         );
         assert_eq!(helper.check_target_version(), false);
     }
@@ -94,7 +94,7 @@ mod tests {
     fn test_check_target_version_mainnet_pass() {
         let helper = UpgradeHelper::new(
             network::Network::Mainnet,
-            "v14.0.0".to_string(),
+            "v14.0.0",
         );
         assert_eq!(helper.check_target_version(), true);
     }
@@ -103,7 +103,7 @@ mod tests {
     fn test_check_target_version_mainnet_fail() {
         let helper = UpgradeHelper::new(
             network::Network::Mainnet,
-            "v14.0.0-rc1".to_string(),
+            "v14.0.0-rc1",
         );
         assert_eq!(helper.check_target_version(), false);
     }

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,110 +1,26 @@
-use regex::Regex;
 use crate::network::Network;
 
 pub struct UpgradeHelper {
     pub network: Network,
+    pub previous_version: String,
     pub target_version: String,
+    pub proposal_name: String,
 }
 
 impl UpgradeHelper {
     /// Creates a new instance of the upgrade helper.
-    /// 
-    /// # Arguments
-    /// 
-    /// * `network` - The network type used.
-    /// * `target_version` - The target version to upgrade to.
-    pub fn new(network: Network, target_version: &str) -> UpgradeHelper {
+    pub fn new(
+        network: Network,
+        previous_version: &str,
+        target_version: &str,
+    ) -> UpgradeHelper {
+        let proposal_name = format!("Evmos {} {} Upgrade", network, target_version);
+
         UpgradeHelper {
-            network: network,
+            network,
+            previous_version: previous_version.to_string(),
             target_version: target_version.to_string(),
+            proposal_name,
         }
-    }
-
-    /// Returns a boolean value if the defined target version fits 
-    /// the requirements for the selected network type.
-    /// The target version must be in the format `vX.Y.Z`.
-    /// Testnet upgrades must use a release candidate with the suffix `-rcX`. 
-    pub fn check_target_version(&self) -> bool {
-        let re: Regex;
-
-        match self.network {
-            Network::LocalNode => {
-                re = Regex::new(r"^v\d+\.\d{1}\.\d+(-rc\d+)*$").unwrap();
-            },
-            Network::Testnet => {
-                re = Regex::new(r"^v\d+\.\d{1}\.\d+-rc\d+$").unwrap();
-            },
-            Network::Mainnet => {
-                re = Regex::new(r"^v\d+\.\d{1}\.\d+$").unwrap();
-            },
-        }
-
-        let valid_version = re.is_match(&self.target_version);
-        if valid_version { 
-            true 
-        } else { 
-            println!("Invalid target version for {}: {}", self.network, self.target_version); // TODO: return error here instead
-            false 
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::network;
-
-    #[test]
-    fn test_check_target_version_local_node_pass() {
-        let helper = UpgradeHelper::new( 
-            network::Network::LocalNode, 
-            "v14.0.0",
-        );
-        assert_eq!(helper.check_target_version(), true);
-    }
-
-    #[test]
-    fn test_check_target_version_local_node_fail() {
-        let helper = UpgradeHelper::new( 
-            network::Network::LocalNode, 
-            "v14.0",
-        );
-        assert_eq!(helper.check_target_version(), false);
-    }
-
-    #[test]
-    fn test_check_target_version_testnet_pass() {
-        let helper = UpgradeHelper::new(
-            network::Network::Testnet,
-            "v14.0.0-rc1",
-        );
-        assert_eq!(helper.check_target_version(), true);
-    }
-
-    #[test]
-    fn test_check_target_version_testnet_fail() {
-        let helper = UpgradeHelper::new(
-            network::Network::Testnet,
-            "v14.0.0",
-        );
-        assert_eq!(helper.check_target_version(), false);
-    }
-
-    #[test]
-    fn test_check_target_version_mainnet_pass() {
-        let helper = UpgradeHelper::new(
-            network::Network::Mainnet,
-            "v14.0.0",
-        );
-        assert_eq!(helper.check_target_version(), true);
-    }
-
-    #[test]
-    fn test_check_target_version_mainnet_fail() {
-        let helper = UpgradeHelper::new(
-            network::Network::Mainnet,
-            "v14.0.0-rc1",
-        );
-        assert_eq!(helper.check_target_version(), false);
     }
 }

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -39,10 +39,10 @@ pub fn get_used_network() -> Network {
 }
 
 /// Prompts the user to input the target version to upgrade to.
-pub fn get_target_version() -> String {
+pub fn get_text(prompt: &str) -> String {
     let target_version: String;
     // Prompt the user to input the desired target version
-    let result = inquire::Text::new("Target version to upgrade to:")
+    let result = inquire::Text::new(prompt)
         .prompt();
     match result {
         Ok(version) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,10 +33,24 @@ fn main() {
         "v0.0.1", // TODO: get previous version from proposals?
     );
     match proposal_res {
-        Ok(proposal) => println!("{}", proposal),
         Err(err) => {
             println!("Error: {}", err);
             process::exit(1);
         },
+        _ => {},
+    }
+
+    // Write proposal to file
+    let write_res = proposal::write_proposal_to_file(
+        proposal_res.unwrap().as_str(),
+        upgrade_helper.network,
+        upgrade_helper.target_version.as_str(),
+    );
+    match write_res {
+        Err(err) => {
+            println!("Error: {}", err);
+            process::exit(1);
+        },
+        _ => {},
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ fn main() {
 
     // Create an instance of the helper
     let upgrade_helper = helper::UpgradeHelper::new(
-        used_network, target_version,
+        used_network, target_version.as_str(),
     );
 
     // Check the target version
@@ -23,14 +23,14 @@ fn main() {
     }
 
     // Check if release was already created
-    let release_exists = release::check_release_exists(upgrade_helper.target_version);
+    let release_exists = release::check_release_exists(upgrade_helper.target_version.as_str());
     println!("Release exists: {}", release_exists.unwrap());
 
     // Prepare proposal
     let proposal_res = proposal::prepare_proposal(
         upgrade_helper.network,
-        upgrade_helper.target_version,
-        "v0.0.1".to_string(), // TODO: get previous version from proposals?
+        upgrade_helper.target_version.as_str(),
+        "v0.0.1", // TODO: get previous version from proposals?
     );
     match proposal_res {
         Ok(proposal) => println!("{}", proposal),

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,9 @@ fn main() {
     );
     match proposal_res {
         Ok(proposal) => println!("{}", proposal),
-        Err(err) => println!("Error: {}", err),
+        Err(err) => {
+            println!("Error: {}", err);
+            process::exit(1);
+        },
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod helper;
 mod inputs;
 mod network;
 mod release;
+mod proposal;
 
 use std::process;
 
@@ -23,5 +24,16 @@ fn main() {
 
     // Check if release was already created
     let release_exists = release::check_release_exists(upgrade_helper.target_version);
-    println!("Release exists: {}", release_exists.unwrap())
+    println!("Release exists: {}", release_exists.unwrap());
+
+    // Prepare proposal
+    let proposal_res = proposal::prepare_proposal(
+        upgrade_helper.network,
+        upgrade_helper.target_version,
+        "v0.0.1".to_string(), // TODO: get previous version from proposals?
+    );
+    match proposal_res {
+        Ok(proposal) => println!("{}", proposal),
+        Err(err) => println!("Error: {}", err),
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,24 +3,38 @@ mod inputs;
 mod network;
 mod release;
 mod proposal;
+mod version;
 
 use std::process;
 
 fn main() {
-    // Prompt the user for the necessary input
+    // Query and check the network to use
     let used_network = inputs::get_used_network();
-    let target_version = inputs::get_target_version();
+
+    // Query and check the version to upgrade from
+    let previous_version = inputs::get_text("Previous version to upgrade from:");
+    let valid_version = version::is_valid_version(previous_version.as_str());
+    if !valid_version {
+        println!("Invalid previous version: {}", previous_version);
+        process::exit(1);
+    }
+
+    // Query and check the target version to upgrade to
+    let target_version = inputs::get_text("Target version to upgrade to:");
+    let valid_version = version::is_valid_target_version(
+        used_network, target_version.as_str(),
+    );
+    if !valid_version {
+        println!("Invalid target version for {}: {}", used_network, target_version);
+        process::exit(1);
+    }
 
     // Create an instance of the helper
     let upgrade_helper = helper::UpgradeHelper::new(
-        used_network, target_version.as_str(),
+        used_network,
+        previous_version.as_str(),
+        target_version.as_str(),
     );
-
-    // Check the target version
-    let valid_version = upgrade_helper.check_target_version();
-    if !valid_version {
-        process::exit(1);
-    }
 
     // Check if release was already created
     let release_exists = release::check_release_exists(upgrade_helper.target_version.as_str());

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,11 +41,7 @@ fn main() {
     println!("Release exists: {}", release_exists.unwrap());
 
     // Prepare proposal
-    let proposal_res = proposal::prepare_proposal(
-        upgrade_helper.network,
-        upgrade_helper.target_version.as_str(),
-        "v0.0.1", // TODO: get previous version from proposals?
-    );
+    let proposal_res = proposal::prepare_proposal(&upgrade_helper);
     match proposal_res {
         Err(err) => {
             println!("Error: {}", err);

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 // Enum to represent different network options
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum Network {
     LocalNode,
     Testnet,

--- a/src/proposal.rs
+++ b/src/proposal.rs
@@ -1,17 +1,18 @@
-extern crate handlebars;
-
-use handlebars::RenderError;
+use handlebars::{
+    Handlebars,
+    RenderError,
+};
 use serde_json::json;
 use crate::network::Network;
 
 pub fn prepare_proposal(
     network: Network,
-    target_version: String,
-    previous_version: String,
+    target_version: &str,
+    previous_version: &str,
 ) -> Result<String, RenderError> {
     let proposal_name = format!("Evmos {} {} Upgrade", network, target_version);
 
-    let mut handlebars = handlebars::Handlebars::new();
+    let mut handlebars = Handlebars::new();
     handlebars
         .set_strict_mode(true);
 
@@ -43,8 +44,8 @@ mod tests {
     fn test_prepare_proposal_pass() {
         let result = prepare_proposal(
             Network::Mainnet,
-            "v0.1.0".to_string(),
-            "v0.0.1".to_string(),
+            "v0.1.0",
+            "v0.0.1",
         );
         assert!(result.is_ok())
     }

--- a/src/proposal.rs
+++ b/src/proposal.rs
@@ -1,0 +1,51 @@
+extern crate handlebars;
+
+use handlebars::RenderError;
+use serde_json::json;
+use crate::network::Network;
+
+pub fn prepare_proposal(
+    network: Network,
+    target_version: String,
+    previous_version: String,
+) -> Result<String, RenderError> {
+    let proposal_name = format!("Evmos {} {} Upgrade", network, target_version);
+
+    let mut handlebars = handlebars::Handlebars::new();
+    handlebars
+        .set_strict_mode(true);
+
+    handlebars
+        .register_template_file("proposal", "templates/proposal.hbs")
+        .unwrap();
+
+    let data = json!({
+        "author": "Malte Herrmann, Evmos Core Team",
+        "name": proposal_name,
+        "height": 0, // TODO: get height from Mintscan?
+        "version": target_version,
+        "prev_version": previous_version,
+        "features": "- neue Features",
+        "diff_link": format!("https://github.com/evmos/evmos/compare/{}..{}", 
+            previous_version, 
+            target_version,
+        ),
+    });
+
+    handlebars.render("proposal", &data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_prepare_proposal_pass() {
+        let result = prepare_proposal(
+            Network::Mainnet,
+            "v0.1.0".to_string(),
+            "v0.0.1".to_string(),
+        );
+        assert!(result.is_ok())
+    }
+}

--- a/src/proposal.rs
+++ b/src/proposal.rs
@@ -17,7 +17,7 @@ pub fn prepare_proposal(
         .set_strict_mode(true);
 
     handlebars
-        .register_template_file("proposal", "templates/proposal.hbs")
+        .register_template_file("proposal", "src/templates/proposal.hbs")
         .unwrap();
 
     let data = json!({

--- a/src/proposal.rs
+++ b/src/proposal.rs
@@ -22,15 +22,18 @@ pub fn prepare_proposal(
 
     let data = json!({
         "author": "Malte Herrmann, Evmos Core Team",
-        "name": proposal_name,
-        "height": 0, // TODO: get height from Mintscan?
-        "version": target_version,
-        "prev_version": previous_version,
-        "features": "- neue Features",
         "diff_link": format!("https://github.com/evmos/evmos/compare/{}..{}", 
             previous_version, 
             target_version,
         ),
+        "estimated_time": "4PM UTC, Monday, Sept. 25th, 2023",
+        "features": "- neue Features",
+        "height": 0, // TODO: get height from Mintscan?
+        "name": proposal_name,
+        "network": format!("{}", network),
+        "previous_version": previous_version,
+        "version": target_version,
+        "voting_time": if matches!(network, Network::Testnet) { "12 hours" } else { "120 hours" },
     });
 
     handlebars.render("proposal", &data)
@@ -47,6 +50,10 @@ mod tests {
             "v0.1.0",
             "v0.0.1",
         );
-        assert!(result.is_ok())
+        assert!(
+            result.is_ok(), 
+            "Error rendering proposal: {}",
+            result.unwrap_err(),
+        );
     }
 }

--- a/src/release.rs
+++ b/src/release.rs
@@ -2,7 +2,7 @@ extern crate reqwest;
 
 /// Checks if the release for the target version already exists by 
 /// sending a HTTP request to the GitHub release page.
-pub fn check_release_exists(version: String) -> Result<bool, reqwest::Error> {
+pub fn check_release_exists(version: &str) -> Result<bool, reqwest::Error> {
     let release_url = format!("https://github.com/evmos/evmos/releases/tag/{}", version);
 
     let resp = reqwest::blocking::get(release_url)?;
@@ -22,11 +22,11 @@ mod tests {
 
     #[test]
     fn test_check_release_exists_pass() {
-        assert_eq!(check_release_exists("v14.0.0".to_string()).unwrap(), true);
+        assert_eq!(check_release_exists("v14.0.0").unwrap(), true);
     }
 
     #[test]
     fn test_check_release_exists_fail() {
-        assert_eq!(check_release_exists("v14.0.8".to_string()).unwrap(), false);
+        assert_eq!(check_release_exists("v14.0.8").unwrap(), false);
     }
 }

--- a/src/templates/proposal.hbs
+++ b/src/templates/proposal.hbs
@@ -1,0 +1,26 @@
+# Description
+
+## Author
+
+{{author}}
+
+## Software Upgrade Being Scheduled With This Proposal
+
+If successful, this proposal will schedule an Evmos {{network}} software upgrade at block height {{height}} (Mintscan estimates this to be around {{estimated_time}}) from its current version {{previous_version}} to {{version}}. This proposal has a voting time of {{voting_time}} hours.
+
+## Motivation
+
+By proposing a scheduled upgrade, we want to implement a smooth and transparent upgrade process, that is first proposed on Testnet and then on Mainnet. Software upgrades generally aim to improve current performance and add new features to the Evmos chain. For more information on the types of upgrades, please visit our [Software Upgrade Guide](https://docs.evmos.org/validate/upgrades).
+
+## Impact
+
+Evmos {{version}} contains the following enhancements:
+
+{{features}}
+
+A full changelog can be found [here]({{diff_link}}).
+
+## Testing
+
+The Evmos core team created an End-to-End testing suite that performs the software upgrade locally. These tests have been completed successfully for this upgrade. The instructions on how to run the End-to-End testing suite can be found [here](https://github.com/evmos/evmos/blob/main/tests/e2e/README.md). Additionally, the upgrade has been manually performed locally with a multi-node setup.
+On top of the upgrade tests, the Evmos team runs performance tests to monitor the impact of new versions.

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,108 @@
+use crate::network::Network;
+use regex::Regex;
+
+/// Returns a boolean value if the defined version fulfills the semantic
+/// versioning requirements.
+pub fn is_valid_version(version: &str) -> bool {
+    let is_valid = Regex::new(r"^v\d+\.\d+\.\d+(-rc\d+)*$")
+        .unwrap()
+        .is_match(version);
+
+    if is_valid { true } else { false }
+}
+
+/// Returns a boolean value if the defined target version fits
+/// the requirements for the selected network type.
+/// The target version must be in the format `vX.Y.Z`.
+/// Testnet upgrades must use a release candidate with the suffix `-rcX`.
+pub fn is_valid_target_version(
+    network: Network,
+    target_version: &str,
+) -> bool {
+    let re: Regex;
+
+    match network {
+        Network::LocalNode => {
+            re = Regex::new(r"^v\d+\.\d{1}\.\d+(-rc\d+)*$").unwrap();
+        },
+        Network::Testnet => {
+            re = Regex::new(r"^v\d+\.\d{1}\.\d+-rc\d+$").unwrap();
+        },
+        Network::Mainnet => {
+            re = Regex::new(r"^v\d+\.\d{1}\.\d+$").unwrap();
+        },
+    }
+
+    let valid_version = re.is_match(target_version);
+    if valid_version {
+        true
+    } else {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::network;
+
+    #[test]
+    fn test_is_valid_version_pass() {
+        assert_eq!(is_valid_version("v14.0.0"), true);
+        assert_eq!(is_valid_version("v14.0.0-rc1"), true);
+    }
+
+    #[test]
+    fn test_is_valid_version_fail() {
+        assert_eq!(is_valid_version("v14.0."), false);
+        assert_eq!(is_valid_version("v.0.1"), false);
+    }
+
+    #[test]
+    fn test_is_valid_target_version_local_node_pass() {
+        assert_eq!(is_valid_target_version(
+            network::Network::LocalNode,
+            "v14.0.0",
+        ), true);
+    }
+
+    #[test]
+    fn test_is_valid_target_version_local_node_fail() {
+        assert_eq!(is_valid_target_version(
+            network::Network::LocalNode,
+            "v14.0",
+        ), false);
+    }
+
+    #[test]
+    fn test_is_valid_target_version_testnet_pass() {
+        assert_eq!(is_valid_target_version(
+            network::Network::Testnet,
+            "v14.0.0-rc1",
+        ), true);
+    }
+
+    #[test]
+    fn test_is_valid_target_version_testnet_fail() {
+        assert_eq!(is_valid_target_version(
+            network::Network::Testnet,
+            "v14.0.0",
+        ), false);
+    }
+
+    #[test]
+    fn test_is_valid_target_version_mainnet_pass() {
+        assert_eq!(is_valid_target_version(
+            network::Network::Mainnet,
+            "v14.0.0",
+        ), true);
+    }
+
+    #[test]
+    fn test_is_valid_target_version_mainnet_fail() {
+        assert_eq!(is_valid_target_version(
+            network::Network::Mainnet,
+            "v14.0.0-rc1",
+        ), false);
+    }
+}


### PR DESCRIPTION
This PR adds basic functionality to prepare the proposal contents and write them to a Markdown file. 
This is done with the [handlebars crate](https://crates.io/crates/handlebars) for templating.

----

Closes #5 